### PR TITLE
real-time-qa2

### DIFF
--- a/Assets/Scenes/Auditorium.unity
+++ b/Assets/Scenes/Auditorium.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 0.6
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.10625559, g: 0.06950926, b: 0.047635145, a: 0.6}
+  m_IndirectSpecularColor: {r: 0.11796006, g: 0.08084667, b: 0.060867075, a: 0.6}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -5597,6 +5597,7 @@ MonoBehaviour:
         m_CallState: 2
   transcriptionLogger: {fileID: 1790734354}
   transcriptionProcessor: {fileID: 824604203}
+  timerController: {fileID: 1099491833}
 --- !u!1 &1451883725
 GameObject:
   m_ObjectHideFlags: 0
@@ -6847,9 +6848,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c8cafa2e5ec64e44837b8a3c913fbcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _textComponent: {fileID: 1790734353}
   _timerController: {fileID: 1099491833}
-  _partialTextComponent: {fileID: 399625863}
+  _fullText: {fileID: 1790734353}
 --- !u!222 &1790734355
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -8153,7 +8153,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   runtimeConfiguration:
-    witConfiguration: {fileID: 11400000, guid: 7ea62e27e62143e4da2c2a519e43a897, type: 2}
+    witConfiguration: {fileID: 11400000, guid: bfdfa3e04c8764660ba03d64aa58eb42, type: 2}
     minKeepAliveVolume: 50
     minKeepAliveTimeInSeconds: 300
     minTranscriptionKeepAliveTimeInSeconds: 300

--- a/Assets/Scripts/CommunicationManager.cs
+++ b/Assets/Scripts/CommunicationManager.cs
@@ -4,6 +4,7 @@ using OpenAI;
 using UnityEngine;
 using UnityEngine.Events;
 using System.Text.RegularExpressions;
+using UI;
 
 public class CommunicationManager : MonoBehaviour
 {
@@ -24,6 +25,24 @@ public class CommunicationManager : MonoBehaviour
     private OpenAIApi openAI = new OpenAIApi(OpenAIConfig.ApiKey);
     private List<ChatMessage> messages = new List<ChatMessage>();
     private static readonly List<string> voices = new List<string> { "alloy", "echo", "fable", "onyx", "nova", "shimmer" };
+
+    private float chatGPTRequestInterval = 30.0f;
+    private float lastChatGPTRequestTime;
+    public TimerController timerController;
+
+    private void Start()
+    {
+        lastChatGPTRequestTime = timerController.GetElapsedTimeInSeconds();
+    }
+
+    private void Update()
+    {
+        if (timerController.GetElapsedTimeInSeconds() - lastChatGPTRequestTime >= chatGPTRequestInterval)
+        {
+            AskChatGPT();
+            lastChatGPTRequestTime = timerController.GetElapsedTimeInSeconds();
+        }
+    }
 
     private string GenerateCombinedText()
     {
@@ -63,14 +82,14 @@ public class CommunicationManager : MonoBehaviour
         '''";
 
         string speechLogText = "";
-        
+
         // transcription without timestamps
         // List<string> list = transcriptionLogger.GetTranscriptionList();
         // foreach (string transcription in list)
         // {
         //     speechLogText += transcription + "\n";
         // }
-        
+
         // timestamped transcriptione
         // example format:
         // 00:01 - Good morning, everyone.

--- a/Assets/Scripts/TranscriptionLogger.cs
+++ b/Assets/Scripts/TranscriptionLogger.cs
@@ -1,62 +1,78 @@
 using TMPro;
 using UnityEngine;
+using System;
 using System.Collections.Generic;
 using UI;
 
 public class TranscriptionLogger : MonoBehaviour
 {
-    [SerializeField] private TextMeshProUGUI _textComponent; // UI component to display the transcript
-    [SerializeField] private TimerController _timerController; // Controller to manage timing
+    #region UI
 
-    [SerializeField] TextMeshProUGUI _partialTextComponent;
-    private string _previousText; // Variable to store the text from the last update
-    private List<string> transcriptionList; // List to store the full transcript (without timestamps)
-    private List<(string, string)> transcriptionTimeList; // List to store the full transcript (with timestamps)
+    [SerializeField] private TimerController _timerController;
+    [SerializeField] private TextMeshProUGUI _fullText; // complete sentence with no pauses
 
-    // Speaking pace calculation
-    private List<float> sectionAverages = new List<float>(); // Average speaking pace per section
-    private float sectionStartTime; // Time when the current section started
-    private float updateInterval = 10.0f; // Duration for each section in seconds (using a shorter interval for testing)
-    private int wordCountThisSection = 0; // Word count in the current section
-    private int totalWordCount = 0; // Total words counted
-    private float totalTimeElapsed = 0; // Total time elapsed since the start of the section
-    private float overallAverageWPM = 0;
-    private float updateWpmInterval = 2.0f; // Update every 2 seconds
-    private float lastUpdateTime; // Time of the last update
-    private float lastWpmUpdateTime; // Time of the last WPM update
+    #endregion
+
+    #region Transcriptions
+
+    private string _previousText; // previously saved text
+    private List<string> transcriptionList; // full transcript (without timestamps)
+    private List<(string, string)> transcriptionTimeList; // full transcript (with timestamps)
+
+    #endregion
+
+    #region Speaking Pace
+
+    private float sectionInterval;
+    private float updateWpmInterval;
+    private float lastWpmUpdateTime;
+    private List<float> sectionAverages;
+    private float sectionStartTime;
+    private int sectionWordCount;
+    private float overallAverageWPM;
+    private int totalWordCount;
+    private float startTime;
+
+    #endregion
+
+    #region Unity
 
     private void Start()
     {
+        // transcriptions
         _previousText = string.Empty;
         transcriptionList = new List<string>();
         transcriptionTimeList = new List<(string, string)>();
-        sectionStartTime = Time.time;
-        lastUpdateTime = Time.time;
-        lastWpmUpdateTime = 0;
+
+        // section
+        sectionInterval = 10.0f; // each section is 10 seconds
+        sectionWordCount = 0;
+        sectionStartTime = _timerController.GetElapsedTimeInSeconds();
+        sectionAverages = new List<float>();
+
+        // total
+        updateWpmInterval = 2.0f; // update wpm every 2 seconds
+        lastWpmUpdateTime = _timerController.GetElapsedTimeInSeconds();
+        totalWordCount = 0;
+        startTime = _timerController.GetElapsedTimeInSeconds();
+        overallAverageWPM = 0.0f;
     }
 
     private void Update()
     {
-        if (_textComponent == null)
+        // Component checks
+        if (_timerController == null || _fullText == null)
         {
-            Debug.LogError("TranscriptionLogger: _textComponent is not assigned!");
             return;
         }
 
-        if (_timerController == null)
-        {
-            Debug.LogError("TranscriptionLogger: _timerController is not assigned!");
-            return;
-        }
-
-        // Only proceed with updates if the timer is currently running
         if (!_timerController.IsRunning())
         {
             return;
         }
 
-        // Update the transcription list and word counts if it has changed
-        string currentText = _textComponent.text;
+        // Update the transcription list and word counts
+        string currentText = _fullText.text;
         if (currentText != _previousText)
         {
             UpdateTranscriptionLists(currentText);
@@ -64,96 +80,70 @@ public class TranscriptionLogger : MonoBehaviour
             _previousText = currentText;
         }
 
-        // Update the time elapsed and calculate the section average at regular intervals
-        if (Time.time - lastUpdateTime >= updateInterval)
-        {
-            totalTimeElapsed += Time.time - lastUpdateTime;
-            lastUpdateTime = Time.time;
-
-            if (Time.time - sectionStartTime >= updateInterval)
-            {
-                CalculateSectionAverage();
-            }
-        }
-
-        // Update the overall average WPM at regular intervals
+        // Calculate the overall average WPM
         if (_timerController.GetElapsedTimeInSeconds() - lastWpmUpdateTime >= updateWpmInterval)
         {
-            // Time to update
-            overallAverageWPM = CalculateOverallAverage();
-            lastWpmUpdateTime = _timerController.GetElapsedTimeInSeconds(); // Update lastWpmUpdateTime to the current time
+            overallAverageWPM = (totalWordCount / (_timerController.GetElapsedTimeInSeconds() - startTime)) * 60.0f;
+            lastWpmUpdateTime =  _timerController.GetElapsedTimeInSeconds();
+        }
+
+        // Calculate the section average WPM
+        if (_timerController.GetElapsedTimeInSeconds() - sectionStartTime >= sectionInterval)
+        {
+            float wpm = (sectionWordCount / sectionInterval) * 60.0f;
+            sectionAverages.Add(wpm);
+            sectionStartTime = _timerController.GetElapsedTimeInSeconds();
+            sectionWordCount = 0;
         }
     }
 
-    // Update the transcription list and the timestamp list
+    #endregion
+
+    #region Helper Methods
     private void UpdateTranscriptionLists(string currentText)
     {
         transcriptionList.Add(currentText);
         string currentTime = _timerController.GetCurrentTime();
-        transcriptionTimeList.Add((currentTime, currentText));
+        transcriptionTimeList.Add((currentTime, currentText)); // logged time is when the sentence ended
     }
 
-    // Update word counts for the current and overall counts
     private void UpdateWordCounts(string currentText)
     {
-        int newWords = 0;
-
-        if (currentText.Length > _previousText.Length)
+        if (string.IsNullOrWhiteSpace(currentText))
         {
-            string addedText = currentText.Substring(_previousText.Length);
-            newWords = CountWords(addedText);
+            return;
         }
-
-        wordCountThisSection += newWords;
-        totalWordCount += newWords;
-    }
-
-    // Calculate the average words per minute for a section
-    private void CalculateSectionAverage()
-    {
-        float timeElapsed = Time.time - sectionStartTime;
-
-        // Ensure that the time elapsed is greater than a certain threshold (e.g., 1 second)
-        if (timeElapsed > 1.0f)
-        {
-            float wordsPerMinute = (wordCountThisSection / timeElapsed) * 60.0f;
-            sectionAverages.Add(wordsPerMinute);
-        }
-
-        // Reset the word count and start time for the next section
-        wordCountThisSection = 0;
-        sectionStartTime = Time.time;
-    }
-
-    // Count the number of words in a given text by splitting it based on spaces
-    private int CountWords(string text)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return 0;
-        }
-
-        return text.Split(' ').Length;
+        string[] words = currentText.Trim().Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        sectionWordCount += words.Length;
+        totalWordCount += words.Length;
     }
 
     // Reset the transcription lists and word counts
     public void ResetTranscript()
     {
+        // transcriptions
         _previousText = string.Empty;
-        _textComponent.text = "Full transcription:";
-        _partialTextComponent.text = "Partial transcription:";
         transcriptionList.Clear();
         transcriptionTimeList.Clear();
+
+        // speaking pace
         sectionAverages.Clear();
-        totalWordCount = 0;
-        totalTimeElapsed = 0;
-        wordCountThisSection = 0;
-        sectionStartTime = 0;
+        sectionStartTime = _timerController.GetElapsedTimeInSeconds();
+        sectionWordCount = 0;
         overallAverageWPM = 0;
-        lastUpdateTime = 0;
-        lastWpmUpdateTime = 0;
+        startTime = _timerController.GetElapsedTimeInSeconds();
+        totalWordCount = 0;
+
+        // UI text
+        if (_fullText != null)
+        {
+            _fullText.text = string.Empty;
+        }
     }
 
+    #endregion
+
+    #region Getters
     public List<string> GetTranscriptionList()
     {
         return transcriptionList;
@@ -169,21 +159,10 @@ public class TranscriptionLogger : MonoBehaviour
         return sectionAverages;
     }
 
-    // Calculate the overall average words per minute
-    private float CalculateOverallAverage()
-    {
-        int totalWords = 0;
-        foreach (string transcript in transcriptionList)
-        {
-            totalWords += CountWords(transcript);
-        }
-
-        float totalTimeInMinutes = _timerController.GetElapsedTimeInSeconds() / 60.0f;
-        return totalWords / totalTimeInMinutes;
-    }
-
     public float GetOverallAverage()
     {
         return overallAverageWPM;
     }
+
+    #endregion
 }

--- a/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -568,11 +568,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f0ebc320a151d3408ea1e9fce54d40e, type: 3}
   m_Name: OpenXR Package Settings
   m_EditorClassIdentifier: 
-  Keys: 01000000070000000e000000
+  Keys: 01000000070000000e00000004000000
   Values:
   - {fileID: 6180380468575574353}
   - {fileID: 4699180590911513623}
   - {fileID: -4487367132734504541}
+  - {fileID: 7530953090365233496}
 --- !u!114 &50929873711133093
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -997,6 +998,23 @@ MonoBehaviour:
   company: Unity
   priority: 0
   required: 0
+--- !u!114 &7530953090365233496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b5a1f07dc5afe854f9f12a4194aca3fb, type: 3}
+  m_Name: iPhone
+  m_EditorClassIdentifier: 
+  features: []
+  m_renderMode: 1
+  m_depthSubmissionMode: 0
+  m_optimizeBufferDiscards: 0
+  m_symmetricProjection: 0
 --- !u!114 &7600382970813042440
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- Prompt ChatGPT during the presentation (i.e., every 30 seconds) with the accumulated transcription.
- Indicate to the user that the generated questions are ready and enable users to interact with the questions during the speech.
- Refactored ‘TranscriptionLogger.cs’. Some changes include:
  - Removed confusing semantics of partial and full transcriptions. Only used full transcription (_fullText).
  - Optimized the code for runtime by removing redundant loops.
  - More accurate word counting given a string.
